### PR TITLE
feat: support multiple root packages for cross-package analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ It is useful for visualising architecture, dependencies, inheritance and interfa
    codeAtlas {
        formats.set(listOf("plantuml", "mermaid"))
        outputDir.set("docs/diagrams")
-       rootPackage.set("com.example") // Optional: filter classes by package prefix
+       rootPackages.set(listOf("com.example.domain", "com.example.infrastructure")) // Optional: filter classes by package prefixes
        showDetails.set(true) // Optional: include public fields and methods in the diagram
    }
    ```
    - `formats` – list of diagram formats to generate.
    - `outputDir` – directory where the diagram files will be written.
-   - `rootPackage` – optional package prefix to filter classes for analysis. Only classes starting with this prefix will be included.
+   - `rootPackages` – optional list of package prefixes to filter classes for analysis. Only classes starting with these prefixes will be included. Useful for DDD architectures (e.g., `listOf("com.example.domain", "com.example.infrastructure")`).
    - `showDetails` – optional flag to include public fields and methods in the diagram. Default is `false`.
 3. **Run the task**:
    ```sh
@@ -45,13 +45,13 @@ It is useful for visualising architecture, dependencies, inheritance and interfa
 
 You can override extension properties using Gradle project properties (`-P` or `--project-prop`).
 
-Note: When passing properties with dots (e.g., `rootPackage=com.example`), using `--project-prop` is recommended to avoid command line parsing issues, especially on Windows.
+Note: When passing properties with dots (e.g., `rootPackages=com.example.domain,com.example.infrastructure`), using `--project-prop` is recommended to avoid command line parsing issues, especially on Windows.
 
 | Property Name | Example Value | Description |
 |---|---|---|
 | `formats` | `plantuml,mermaid` | Comma-separated list of formats. |
 | `outputDir` | `reports/diagrams` | Output directory path. |
-| `rootPackage` | `com.example` | Package prefix to filter classes. |
+| `rootPackages` | `com.example.domain,com.example.infrastructure` | Comma-separated list of package prefixes to filter classes. |
 | `showDetails` | `true` or `false` | If true, includes public fields and methods in the diagram. (Default: `false`) |
 
 Example usage for all parameters:
@@ -59,12 +59,12 @@ Example usage for all parameters:
 ./gradlew generateDiagrams \
     --project-prop formats=plantuml,mermaid \
     --project-prop outputDir=reports/diagrams \
-    --project-prop rootPackage=com.example \
+    --project-prop rootPackages=com.example.domain,com.example.infrastructure \
     --project-prop showDetails=true
 ```
 Alternatively, on Windows, you might need to use double quotes with `-P`:
 ```sh
-./gradlew generateDiagrams -P"formats=plantuml,mermaid" -P"outputDir=reports/diagrams" -P"rootPackage=com.example" -P"showDetails=true"
+./gradlew generateDiagrams -P"formats=plantuml,mermaid" -P"outputDir=reports/diagrams" -P"rootPackages=com.example.domain,com.example.infrastructure" -P"showDetails=true"
 ```
 
 ## Sample Project

--- a/README_JA.md
+++ b/README_JA.md
@@ -27,13 +27,13 @@ README [英語版](README.md) [日本語版](README_JA.md)
    codeAtlas {
        formats.set(listOf("plantuml", "mermaid"))
        outputDir.set("docs/diagrams")
-       rootPackage.set("com.example") // 任意: パッケージプレフィックスでクラスをフィルタリング
+       rootPackages.set(listOf("com.example.domain", "com.example.infrastructure")) // 任意: パッケージプレフィックスでクラスをフィルタリング
        showDetails.set(true) // 任意: 公開フィールドとメソッドを図に含める
    }
    ```
    - `formats` – 生成したい図のフォーマット一覧。
    - `outputDir` – 図ファイルを書き出すディレクトリ。
-   - `rootPackage` – 解析対象のクラスをフィルタリングするための任意のパッケージプレフィックス。このプレフィックスで始まるクラスのみが含まれます。
+   - `rootPackages` – 解析対象のクラスをフィルタリングするための任意のパッケージプレフィックス。このプレフィックスで始まるクラスのみが含まれます。DDDアーキテクチャの場合、`listOf("com.example.domain", "com.example.infrastructure")`のような値を設定します。
    - `showDetails` – `true`の場合、公開フィールドとメソッドを図に含めます。（デフォルト: `false`）
 
 
@@ -52,22 +52,22 @@ Gradle プロジェクトプロパティ（`-P` または `--project-prop`）を
 |---|---|---|
 | `formats` | `plantuml,mermaid` | カンマ区切りのフォーマット一覧。 |
 | `outputDir` | `reports/diagrams` | 出力ディレクトリパス。 |
-| `rootPackage` | `com.example` | クラスをフィルタリングするパッケージプレフィックス。 |
+| `rootPackages` |  `com.example.domain,com.example.infrastructure` | カンマ区切りのパッケージプレフィックス一覧。 |
 | `showDetails` | `true` または `false` | `true`の場合、公開フィールドとメソッドを図に含めます。（デフォルト: `false`） |
 
-注意: ドット（例: `rootPackage=com.example`）を含むプロパティを渡す場合、特に Windows 環境でのコマンドライン解析の問題を避けるために、`--project-prop`の使用を推奨します。
+注意: ドット（例: `rootPackages=com.example`）を含むプロパティを渡す場合、特に Windows 環境でのコマンドライン解析の問題を避けるために、`--project-prop`の使用を推奨します。
 
 すべてのパラメータの使用例:
 ```sh
 ./gradlew generateDiagrams \
     --project-prop formats=plantuml,mermaid \
     --project-prop outputDir=reports/diagrams \
-    --project-prop rootPackage=com.example \
+    --project-prop rootPackages=com.example.domain,com.example.infrastructure \
     --project-prop showDetails=true
 ```
 または、Windows では `-P` とダブルクォーテーションを使用する必要がある場合があります:
 ```sh
-./gradlew generateDiagrams -P"formats=plantuml,mermaid" -P"outputDir=reports/diagrams" -P"rootPackage=com.example" -P"showDetails=true"
+./gradlew generateDiagrams -P"formats=plantuml,mermaid" -P"outputDir=reports/diagrams" -P"rootPackages=com.example.domain,com.example.infrastructure" -P"showDetails=true"
 ```
 
 ## サンプルプロジェクト

--- a/src/main/java/com/euledge/codeatlas/CodeAtlasExtension.java
+++ b/src/main/java/com/euledge/codeatlas/CodeAtlasExtension.java
@@ -23,11 +23,11 @@ public abstract class CodeAtlasExtension {
     public abstract Property<String> getOutputDir();
 
     /**
-     * Specifies the root package to scan for classes. If empty, all project classes are scanned.
-     * Defaults to "".
-     * @return A Property for the root package name.
+     * Specifies the root packages to scan for classes. If empty, all project classes are scanned.
+     * Defaults to an empty list.
+     * @return A ListProperty for the root package names.
      */
-    public abstract Property<String> getRootPackage();
+    public abstract ListProperty<String> getRootPackages();
 
     /**
      * Specifies whether to include detailed information (public fields and methods) in the diagrams.
@@ -42,7 +42,7 @@ public abstract class CodeAtlasExtension {
     public CodeAtlasExtension() {
         getFormats().convention(java.util.Arrays.asList("plantuml", "mermaid"));
         getOutputDir().convention("build/reports/code-atlas");
-        getRootPackage().convention("");
+        getRootPackages().convention(java.util.Collections.emptyList());
         getShowDetails().convention(false);
     }
 }

--- a/src/main/java/com/euledge/codeatlas/CodeAtlasPlugin.java
+++ b/src/main/java/com/euledge/codeatlas/CodeAtlasPlugin.java
@@ -47,12 +47,18 @@ public class CodeAtlasPlugin implements Plugin<Project> {
                 task.getOutputDir().set(extension.getOutputDir());
             }
 
-            // Configure rootPackage: Command line > Extension
-            Object cmdRootPackage = project.getProperties().get("rootPackage");
-            if (cmdRootPackage != null && cmdRootPackage instanceof String) {
-                task.getRootPackage().set((String) cmdRootPackage);
+            // Configure rootPackages: Command line > Extension
+            Object cmdRootPackages = project.getProperties().get("rootPackages");
+            if (cmdRootPackages != null) {
+                if (cmdRootPackages instanceof String) {
+                    // Assume comma-separated string for list property
+                    task.getRootPackages().set(Arrays.asList(((String) cmdRootPackages).split(",")));
+                } else if (cmdRootPackages instanceof List) {
+                    // If it's already a list
+                    task.getRootPackages().set((List<String>) cmdRootPackages);
+                }
             } else {
-                task.getRootPackage().set(extension.getRootPackage());
+                task.getRootPackages().set(extension.getRootPackages());
             }
 
             // Configure showDetails: Command line > Extension

--- a/src/main/java/com/euledge/codeatlas/CodeAtlasTask.java
+++ b/src/main/java/com/euledge/codeatlas/CodeAtlasTask.java
@@ -16,6 +16,7 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -40,11 +41,11 @@ public abstract class CodeAtlasTask extends DefaultTask {
     public abstract Property<String> getOutputDir();
 
     /**
-     * The root package to scan for classes. If empty, all project classes are scanned.
-     * @return A Property for the root package name.
+     * The root packages to scan for classes. If empty, all project classes are scanned.
+     * @return A ListProperty for the root package names.
      */
     @Input
-    public abstract Property<String> getRootPackage();
+    public abstract ListProperty<String> getRootPackages();
 
     /**
      * Whether to include detailed information (public fields and methods) in the diagrams.
@@ -74,10 +75,10 @@ public abstract class CodeAtlasTask extends DefaultTask {
         }
 
         // Analyze
-        String rootPackage = getRootPackage().get();
+        List<String> rootPackages = getRootPackages().get();
         boolean showDetails = getShowDetails().get();
         ClassAnalyzer analyzer = new ClassAnalyzer();
-        Map<String, ClassNode> classes = analyzer.analyze(classpath, rootPackage, showDetails);
+        Map<String, ClassNode> classes = analyzer.analyze(classpath, rootPackages, showDetails);
         getLogger().lifecycle("Found " + classes.size() + " classes.");
 
         if (classes.isEmpty()) {

--- a/src/main/java/com/euledge/codeatlas/analyzer/ClassAnalyzer.java
+++ b/src/main/java/com/euledge/codeatlas/analyzer/ClassAnalyzer.java
@@ -9,6 +9,7 @@ import java.io.File;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -20,22 +21,22 @@ import java.util.stream.Collectors;
 public class ClassAnalyzer {
 
     /**
-     * Analyzes classes within the specified classpath and root package.
+     * Analyzes classes within the specified classpath and root packages.
      *
      * @param classpath A set of files representing the classpath to be analyzed.
-     * @param rootPackage The root package name to start the scan from. If null or empty, the entire classpath is scanned.
+     * @param rootPackages The root package names to start the scan from. If null or empty, the entire classpath is scanned.
      * @param showDetails If true, collects detailed information about public fields and methods of the classes.
      * @return A map where the key is the class name and the value is the ClassNode.
      */
-    public Map<String, ClassNode> analyze(Set<File> classpath, String rootPackage, boolean showDetails) {
+    public Map<String, ClassNode> analyze(Set<File> classpath, List<String> rootPackages, boolean showDetails) {
         Map<String, ClassNode> classMap = new HashMap<>();
 
         ClassGraph classGraph = new ClassGraph()
                 .overrideClasspath(classpath)
                 .enableAllInfo();
 
-        if (rootPackage != null && !rootPackage.isEmpty()) {
-            classGraph.acceptPackages(rootPackage);
+        if (rootPackages != null && !rootPackages.isEmpty()) {
+            classGraph.acceptPackages(rootPackages.toArray(new String[0]));
         }
 
         try (ScanResult scanResult = classGraph


### PR DESCRIPTION
Closes #3

## Summary
Implements support for specifying multiple root packages to enable cross-package dependency visualization in a single diagram. This is particularly useful for DDD architectures where you want to visualize relationships between different layers like `domain` and `infrastructure`.

## Changes
- Changed `rootPackage` (singular) to `rootPackages` (plural) API
- Now accepts `List<String>` for multiple package prefixes
- Updated all documentation with DDD examples

### Breaking Change
⚠️ **BREAKING CHANGE**: `rootPackage.set()` replaced with `rootPackages.set(listOf())`

**Migration:**
```kotlin
// Before
codeAtlas {
    rootPackage.set("com.example")
}

// After
codeAtlas {
    rootPackages.set(listOf("com.example"))
}
```

## Files Modified
- `CodeAtlasExtension.java`: Property<String> → ListProperty<String>
- `CodeAtlasPlugin.java`: Handle comma-separated package list
- `CodeAtlasTask.java`: Pass List<String> to analyzer
- `ClassAnalyzer.java`: Accept List<String> parameter
- `README.md`: Updated with multiple packages examples
- `README_JA.md`: Updated with multiple packages examples (Japanese)

## Testing
- ✅ Plugin builds successfully
- ✅ Published to local Maven
- ⏳ Sample project tests (manual verification needed)Implements #3

- Changed rootPackage (singular) to rootPackages (plural) API
- Now accepts List<String> for multiple package prefixes
- Useful for DDD architectures (e.g., domain + infrastructure)
- Updated all documentation with examples

BREAKING CHANGE: rootPackage.set() replaced with rootPackages.set(listOf())

Files modified:
- CodeAtlasExtension.java: Property<String> -> ListProperty<String>
- CodeAtlasPlugin.java: Handle comma-separated package list
- CodeAtlasTask.java: Pass List<String> to analyzer
- ClassAnalyzer.java: Accept List<String> parameter
- README.md: Updated with multiple packages examples
- README_JA.md: Updated with multiple packages examples (Japanese)