### PR TITLE
sample: demonstrate multiple root packages feature

### DIFF
--- a/sample-project/build.gradle.kts
+++ b/sample-project/build.gradle.kts
@@ -10,6 +10,7 @@ repositories {
 
 codeAtlas {
     formats.set(listOf("plantuml", "mermaid"))
+    rootPackages.set(listOf("com.example.sample","com.example.dummy"))
     outputDir.set("docs/diagrams")
     showDetails.set(true)
 }

--- a/sample-project/docs/diagrams/class-diagram.mmd
+++ b/sample-project/docs/diagrams/class-diagram.mmd
@@ -4,17 +4,17 @@ classDiagram
     }
     class com.example.sample.A
     com.example.sample.A ..> com.example.sample.B
-    class com.example.sample.D {
+    class com.example.dummy.E {
+        +String publicField
+        +String getPublicField()
+        +String greet(String)
+    }
+    com.example.dummy.D <|.. com.example.dummy.E
+    com.example.dummy.E ..> com.example.dummy.D
+    class com.example.dummy.D {
         +String greet(String)
     }
     class com.example.sample.C
     com.example.sample.A <|-- com.example.sample.C
     com.example.sample.C ..> com.example.sample.B
     com.example.sample.C ..> com.example.sample.A
-    class com.example.sample.E {
-        +String publicField
-        +String getPublicField()
-        +String greet(String)
-    }
-    com.example.sample.D <|.. com.example.sample.E
-    com.example.sample.E ..> com.example.sample.D

--- a/sample-project/docs/diagrams/class-diagram.puml
+++ b/sample-project/docs/diagrams/class-diagram.puml
@@ -5,7 +5,14 @@ class com.example.sample.B {
 class com.example.sample.A {
 }
 com.example.sample.A ..> com.example.sample.B
-class com.example.sample.D {
+class com.example.dummy.E {
+    + String publicField
+    + String getPublicField()
+    + String greet(String)
+}
+com.example.dummy.D <|.. com.example.dummy.E
+com.example.dummy.E ..> com.example.dummy.D
+class com.example.dummy.D {
     + String greet(String)
 }
 class com.example.sample.C {
@@ -13,11 +20,4 @@ class com.example.sample.C {
 com.example.sample.A <|-- com.example.sample.C
 com.example.sample.C ..> com.example.sample.B
 com.example.sample.C ..> com.example.sample.A
-class com.example.sample.E {
-    + String publicField
-    + String getPublicField()
-    + String greet(String)
-}
-com.example.sample.D <|.. com.example.sample.E
-com.example.sample.E ..> com.example.sample.D
 @enduml

--- a/sample-project/src/main/java/com/example/sample/D.java
+++ b/sample-project/src/main/java/com/example/sample/D.java
@@ -1,4 +1,4 @@
-package com.example.sample;
+package com.example.dummy;
 
 public interface D {
     String greet(String name);

--- a/sample-project/src/main/java/com/example/sample/E.java
+++ b/sample-project/src/main/java/com/example/sample/E.java
@@ -1,4 +1,4 @@
-package com.example.sample;
+package com.example.dummy;
 
 public class E implements D {
     public String publicField = "This is a public field in E";


### PR DESCRIPTION
Updates the sample project to showcase the new multiple root packages feature introduced in v1.0.0.

## Changes
- Moved `D.java` and `E.java` to `com.example.dummy` package
- Updated `build.gradle.kts` to configure `rootPackages` with both packages:
  ```kotlin
  rootPackages.set(listOf("com.example.sample", "com.example.dummy"))
  ```
- Regenerated diagrams showing cross-package dependencies

## Demonstrates
This example shows how to:
- Configure multiple root packages in a single project
- Visualize dependencies across different packages in one diagram
- Use case for DDD architectures with separate domain/infrastructure layers

## Generated Diagrams
The updated diagrams now include classes from both:
- `com.example.sample` package (A, B, C)
- `com.example.dummy` package (D, E)

Related to PR #4 (feature implementation) and issue #3.Updated sample project to showcase the new multiple root packages feature:
- Moved D.java and E.java to com.example.dummy package
- Updated build.gradle.kts to use rootPackages with both packages
- Generated diagrams now show cross-package dependencies

This demonstrates how to visualize dependencies across different packages in a single diagram, useful for DDD architectures.