### PR TITLE
chore: bump version to 1.0.0chore: update sample project to use plugin v1.0.0

### DIFF
--- a/sample-project/build.gradle.kts
+++ b/sample-project/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     java
-    id("io.github.euledge.code-atlas") version "0.9.0"
+    id("io.github.euledge.code-atlas") version "1.0.0"
 }
 
 repositories {


### PR DESCRIPTION
Updates the plugin version from 0.9.0 to 1.0.0 to reflect the breaking changes introduced in the multiple root packages feature.

## Changes
- Updated `build.gradle.kts`: version 0.9.0 → 1.0.0
- Updated `sample-project/build.gradle.kts`: plugin version 0.9.0 → 1.0.0

## Reason
Version 1.0.0 includes breaking API changes:
- `rootPackage` (singular) → `rootPackages` (plural)
- Requires migration for existing users

## Related
- PR #4: Feature implementation (merged)
- PR #5: Release notes documentation
- PR #6: Sample project multi-package demo (merged)
- Issue #3: Multiple root packages support

This completes the version update for the v1.0.0 release.